### PR TITLE
Add EER configuration tab and code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ radio_dialog.c\
 receiver_dialog.c\
 transmitter_dialog.c\
 pa_dialog.c\
+eer_dialog.c\
 wideband_dialog.c\
 about_dialog.c\
 button_text.c\
@@ -101,6 +102,7 @@ radio_dialog.h\
 receiver_dialog.h\
 transmitter_dialog.h\
 pa_dialog.h\
+eer_dialog.h\
 wideband_dialog.h\
 about_dialog.h\
 button_text.h\
@@ -148,6 +150,7 @@ radio_dialog.o\
 receiver_dialog.o\
 transmitter_dialog.o\
 pa_dialog.o\
+eer_dialog.o\
 wideband_dialog.o\
 about_dialog.o\
 button_text.o\

--- a/configure_dialog.c
+++ b/configure_dialog.c
@@ -37,6 +37,7 @@
 #include "transmitter_dialog.h"
 #include "puresignal_dialog.h"
 #include "pa_dialog.h"
+#include "eer_dialog.h"
 #include "oc_dialog.h"
 #include "xvtr_dialog.h"
 #include "receiver_dialog.h"
@@ -101,6 +102,7 @@ GtkWidget *create_configure_dialog(RADIO *radio,int tab) {
   gtk_notebook_append_page(GTK_NOTEBOOK(notebook),create_transmitter_dialog(radio->transmitter),gtk_label_new("TX"));
   gtk_notebook_append_page(GTK_NOTEBOOK(notebook),create_puresignal_dialog(radio->transmitter),gtk_label_new("Pure Signal"));
   gtk_notebook_append_page(GTK_NOTEBOOK(notebook),create_pa_dialog(radio),gtk_label_new("PA"));
+  gtk_notebook_append_page(GTK_NOTEBOOK(notebook),create_eer_dialog(radio),gtk_label_new("EER"));
   gtk_notebook_append_page(GTK_NOTEBOOK(notebook),create_oc_dialog(radio),gtk_label_new("OC"));
   gtk_notebook_append_page(GTK_NOTEBOOK(notebook),create_xvtr_dialog(radio),gtk_label_new("XVTR"));
 

--- a/eer_dialog.c
+++ b/eer_dialog.c
@@ -1,0 +1,166 @@
+/* Copyright (C)
+* 2018 - Claudio Girardi, IN3OTD/DK1CG
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*
+*/
+
+#include <gtk/gtk.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <wdsp.h>
+
+#include "receiver.h"
+#include "transmitter.h"
+#include "wideband.h"
+#include "discovered.h"
+#include "adc.h"
+#include "radio.h"
+
+static void enable_cb(GtkWidget *widget, gpointer data) {
+  RADIO *radio=(RADIO *)data;
+  radio->classE=gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (widget));
+  transmitter_enable_eer(radio->transmitter,radio->classE);
+}
+
+static void amiq_cb(GtkWidget *widget, gpointer data) {
+  TRANSMITTER *tx=(TRANSMITTER *)data;
+  transmitter_set_eer_mode_amiq(tx,gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (widget)));
+}
+
+static void delays_en_cb(GtkWidget *widget, gpointer data) {
+  TRANSMITTER *tx=(TRANSMITTER *)data;
+  transmitter_enable_eer_delays(tx,gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (widget)));
+}
+
+static void eer_pgain_cb(GtkWidget *widget, gpointer data) {
+  TRANSMITTER *tx=(TRANSMITTER *)data;
+  transmitter_set_eer_pgain(tx,gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)));
+}
+
+static void eer_pdelay_cb(GtkWidget *widget, gpointer data) {
+  TRANSMITTER *tx=(TRANSMITTER *)data;
+  transmitter_set_eer_pdelay(tx,gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)));
+}
+
+static void eer_mgain_cb(GtkWidget *widget, gpointer data) {
+  TRANSMITTER *tx=(TRANSMITTER *)data;
+  transmitter_set_eer_mgain(tx,gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)));
+}
+
+static void eer_mdelay_cb(GtkWidget *widget, gpointer data) {
+  TRANSMITTER *tx=(TRANSMITTER *)data;
+  transmitter_set_eer_mdelay(tx,gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)));
+}
+
+static void eer_pwm_max_cb(GtkWidget *widget, gpointer data) {
+  TRANSMITTER *tx=(TRANSMITTER *)data;
+  tx->eer_pwm_max=gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
+}
+
+static void eer_pwm_min_cb(GtkWidget *widget, gpointer data) {
+  TRANSMITTER *tx=(TRANSMITTER *)data;
+  tx->eer_pwm_min=gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
+}
+
+GtkWidget *create_eer_dialog(RADIO *r) {
+  TRANSMITTER *tx=(TRANSMITTER *)r->transmitter;
+
+  GtkWidget *eer_frame=gtk_frame_new("EER");
+  GtkWidget *eer_grid=gtk_grid_new();
+  gtk_grid_set_row_homogeneous(GTK_GRID(eer_grid),FALSE);
+  gtk_grid_set_column_homogeneous(GTK_GRID(eer_grid),FALSE);
+  gtk_grid_set_column_spacing(GTK_GRID(eer_grid),5);
+  gtk_grid_set_row_spacing(GTK_GRID(eer_grid),5);
+  gtk_container_add(GTK_CONTAINER(eer_frame),eer_grid);
+
+  GtkWidget *enable_b=gtk_check_button_new_with_label("Transmit in EER mode");
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (enable_b), tx->eer);
+  g_signal_connect(enable_b,"toggled",G_CALLBACK(enable_cb),r);
+  gtk_grid_attach(GTK_GRID(eer_grid),enable_b,0,0,1,1);
+
+  GtkWidget *amiq_b=gtk_check_button_new_with_label("Amplitude Modulate IQ");
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (amiq_b), tx->eer_amiq);
+  g_signal_connect(amiq_b,"toggled",G_CALLBACK(amiq_cb),tx);
+  gtk_grid_attach(GTK_GRID(eer_grid),amiq_b,0,1,1,1);
+
+  GtkWidget *delays_en_b=gtk_check_button_new_with_label("Use Delays");
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (delays_en_b), tx->eer_enable_delays);
+  g_signal_connect(delays_en_b,"toggled",G_CALLBACK(delays_en_cb),tx);
+  gtk_grid_attach(GTK_GRID(eer_grid),delays_en_b,0,2,1,1);
+
+  GtkWidget *eer_mgain_label=gtk_label_new("Env Gain");
+  gtk_widget_show(eer_mgain_label);
+  gtk_grid_attach(GTK_GRID(eer_grid),eer_mgain_label,0,3,1,1);
+  GtkWidget *eer_mgain=gtk_spin_button_new_with_range(0,1,0.001);
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(eer_mgain),tx->eer_mgain);
+  gtk_widget_show(eer_mgain);
+  gtk_grid_attach(GTK_GRID(eer_grid),eer_mgain,1,3,1,1);
+  g_signal_connect(eer_mgain,"value-changed",G_CALLBACK(eer_mgain_cb),tx);
+
+  GtkWidget *eer_pdelay_label=gtk_label_new("Env Delay (us)");
+  gtk_widget_show(eer_pdelay_label);
+  gtk_grid_attach(GTK_GRID(eer_grid),eer_pdelay_label,0,4,1,1);
+  GtkWidget *eer_pdelay=gtk_spin_button_new_with_range(0,1000,0.01);
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(eer_pdelay),tx->eer_pdelay);
+  gtk_widget_show(eer_pdelay);
+  gtk_grid_attach(GTK_GRID(eer_grid),eer_pdelay,1,4,1,1);
+  g_signal_connect(eer_pdelay,"value-changed",G_CALLBACK(eer_pdelay_cb),tx);
+
+  GtkWidget *eer_pgain_label=gtk_label_new("Phase Gain");
+  gtk_widget_show(eer_pgain_label);
+  gtk_grid_attach(GTK_GRID(eer_grid),eer_pgain_label,0,5,1,1);
+  GtkWidget *eer_pgain=gtk_spin_button_new_with_range(0,1,0.001);
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(eer_pgain),tx->eer_pgain);
+  gtk_widget_show(eer_pgain);
+  gtk_grid_attach(GTK_GRID(eer_grid),eer_pgain,1,5,1,1);
+  g_signal_connect(eer_pgain,"value-changed",G_CALLBACK(eer_pgain_cb),tx);
+
+  GtkWidget *eer_mdelay_label=gtk_label_new("Phase Delay (us)");
+  gtk_widget_show(eer_mdelay_label);
+  gtk_grid_attach(GTK_GRID(eer_grid),eer_mdelay_label,0,6,1,1);
+  GtkWidget *eer_mdelay=gtk_spin_button_new_with_range(0,1000,0.01);
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(eer_mdelay),tx->eer_mdelay);
+  gtk_widget_show(eer_mdelay);
+  gtk_grid_attach(GTK_GRID(eer_grid),eer_mdelay,1,6,1,1);
+  g_signal_connect(eer_mdelay,"value-changed",G_CALLBACK(eer_mdelay_cb),tx);
+
+  GtkWidget *eer_pwm_frame=gtk_frame_new("PWM Control");
+  GtkWidget *eer_pwm_grid=gtk_grid_new();
+  gtk_grid_set_row_homogeneous(GTK_GRID(eer_pwm_grid),FALSE);
+  gtk_grid_set_column_homogeneous(GTK_GRID(eer_pwm_grid),FALSE);
+  gtk_container_add(GTK_CONTAINER(eer_pwm_frame),eer_pwm_grid);
+  gtk_grid_attach(GTK_GRID(eer_grid),eer_pwm_frame,2,0,1,1);
+
+  GtkWidget *eer_pwm_max_label=gtk_label_new("Maximum (0 - 1023)");
+  gtk_widget_show(eer_pwm_max_label);
+  gtk_grid_attach(GTK_GRID(eer_pwm_grid),eer_pwm_max_label,1,0,1,1);
+  GtkWidget *eer_pwm_max=gtk_spin_button_new_with_range(0,1023,1);
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(eer_pwm_max),tx->eer_pwm_max);
+  gtk_widget_show(eer_pwm_max);
+  gtk_grid_attach(GTK_GRID(eer_pwm_grid),eer_pwm_max,2,0,1,1);
+  g_signal_connect(eer_pwm_max,"value-changed",G_CALLBACK(eer_pwm_max_cb),tx);
+  GtkWidget *eer_pwm_min_label=gtk_label_new("Minimum (0 - 1023)");
+  gtk_widget_show(eer_pwm_min_label);
+  gtk_grid_attach(GTK_GRID(eer_pwm_grid),eer_pwm_min_label,1,1,1,1);
+  GtkWidget *eer_pwm_min=gtk_spin_button_new_with_range(0,1023,1);
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(eer_pwm_min),tx->eer_pwm_min);
+  gtk_widget_show(eer_pwm_min);
+  gtk_grid_attach(GTK_GRID(eer_pwm_grid),eer_pwm_min,2,1,1,1);
+  g_signal_connect(eer_pwm_min,"value-changed",G_CALLBACK(eer_pwm_min_cb),tx);
+
+  return eer_frame;
+}

--- a/eer_dialog.h
+++ b/eer_dialog.h
@@ -1,5 +1,5 @@
 /* Copyright (C)
-* 2018 - John Melton, G0ORX/N6LYT
+* 2018 - Claudio Girardi, IN3OTD/DK1CG
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License
@@ -17,16 +17,4 @@
 *
 */
 
-#ifndef _OLD_PROTOCOL_H
-#define _OLD_PROTOCOL_H
-
-extern void protocol1_stop();
-extern void protocol1_run();
-
-extern void protocol1_init(RADIO *r);
-extern void protocol1_set_mic_sample_rate(int rate);
-
-extern void protocol1_process_local_mic(RADIO *r);
-extern void protocol1_audio_samples(RECEIVER *rx,short left_audio_sample,short right_audio_sample);
-extern void protocol1_iq_samples(int isample,int qsample,int lasample,int rasample);
-#endif
+extern GtkWidget *create_eer_dialog(RADIO *r);

--- a/protocol1.c
+++ b/protocol1.c
@@ -940,12 +940,13 @@ void protocol1_audio_samples(RECEIVER *rx,short left_audio_sample,short right_au
   }
 }
 
-void protocol1_iq_samples(int isample,int qsample) {
+void protocol1_iq_samples(int isample,int qsample,int lasample,int rasample) {
   if(isTransmitting(radio)) {
-    output_buffer[output_buffer_index++]=0;
-    output_buffer[output_buffer_index++]=0;
-    output_buffer[output_buffer_index++]=0;
-    output_buffer[output_buffer_index++]=0;
+    output_buffer[output_buffer_index++]=lasample>>8;
+    output_buffer[output_buffer_index++]=lasample;
+    output_buffer[output_buffer_index++]=rasample>>8;
+    output_buffer[output_buffer_index++]=rasample;
+
     output_buffer[output_buffer_index++]=isample>>8;
     output_buffer[output_buffer_index++]=isample;
     output_buffer[output_buffer_index++]=qsample>>8;
@@ -1499,7 +1500,7 @@ void ozy_send_buffer() {
         output_buffer[C0]=0x22;
         output_buffer[C1]=(radio->transmitter->eer_pwm_min>>2) & 0xFF;
         output_buffer[C2]=radio->transmitter->eer_pwm_min & 0x03;
-        output_buffer[C3]=(radio->transmitter->eer_pwm_max>>3) & 0xFF;
+        output_buffer[C3]=(radio->transmitter->eer_pwm_max>>2) & 0xFF;
         output_buffer[C4]=radio->transmitter->eer_pwm_max & 0x03;
         break;
       case 10:

--- a/radio.c
+++ b/radio.c
@@ -169,7 +169,10 @@ g_print("radio_save_state: %s\n",filename);
 
   sprintf(value,"%d",radio->region);
   setProperty("radio.region",value);
-  
+
+  sprintf(value,"%d",radio->classE);
+  setProperty("radio.classE",value);
+
   sprintf(value,"%d",rigctl_enable);
   setProperty("rigctl_enable",value);
   sprintf(value,"%d",rigctl_port_base);
@@ -301,6 +304,8 @@ void radio_restore_state(RADIO *radio) {
   if(value!=NULL) radio->linein_gain=atoi(value);
   value=getProperty("radio.region");
   if(value!=NULL) radio->region=atoi(value);
+  value=getProperty("radio.classE");
+  if(value!=NULL) radio->classE=atoi(value);
 
   value=getProperty("rigctl_enable");
   if(value!=NULL) rigctl_enable=atoi(value);

--- a/transmitter.c
+++ b/transmitter.c
@@ -137,7 +137,33 @@ void transmitter_save_state(TRANSMITTER *tx) {
   sprintf(name,"transmitter[%d].ctcss_frequency",tx->channel);
   sprintf(value,"%f",tx->ctcss_frequency);
   setProperty(name,value);
-
+  sprintf(name,"transmitter[%d].eer",tx->channel);
+  sprintf(value,"%i",tx->eer);
+  setProperty(name,value);
+  sprintf(name,"transmitter[%d].eer_amiq",tx->channel);
+  sprintf(value,"%i",tx->eer_amiq);
+  setProperty(name,value);
+  sprintf(name,"transmitter[%d].eer_pgain",tx->channel);
+  sprintf(value,"%f",tx->eer_pgain);
+  setProperty(name,value);
+  sprintf(name,"transmitter[%d].eer_mgain",tx->channel);
+  sprintf(value,"%f",tx->eer_mgain);
+  setProperty(name,value);
+  sprintf(name,"transmitter[%d].eer_pdelay",tx->channel);
+  sprintf(value,"%f",tx->eer_pdelay);
+  setProperty(name,value);
+  sprintf(name,"transmitter[%d].eer_mdelay",tx->channel);
+  sprintf(value,"%f",tx->eer_mdelay);
+  setProperty(name,value);
+  sprintf(name,"transmitter[%d].eer_enable_delays",tx->channel);
+  sprintf(value,"%i",tx->eer_enable_delays);
+  setProperty(name,value);
+  sprintf(name,"transmitter[%d].eer_pwm_min",tx->channel);
+  sprintf(value,"%i",tx->eer_pwm_min);
+  setProperty(name,value);
+  sprintf(name,"transmitter[%d].eer_pwm_max",tx->channel);
+  sprintf(value,"%i",tx->eer_pwm_max);
+  setProperty(name,value);
 }
 
 void transmitter_restore_state(TRANSMITTER *tx) {
@@ -234,6 +260,33 @@ void transmitter_restore_state(TRANSMITTER *tx) {
   sprintf(name,"transmitter[%d].ctcss_frequency",tx->channel);
   value=getProperty(name);
   if(value) tx->ctcss_frequency=atof(value);
+  sprintf(name,"transmitter[%d].eer",tx->channel);
+  value=getProperty(name);
+  if(value) tx->eer=atoi(value);
+  sprintf(name,"transmitter[%d].eer_amiq",tx->channel);
+  value=getProperty(name);
+  if(value) tx->eer_amiq=atoi(value);
+  sprintf(name,"transmitter[%d].eer_pgain",tx->channel);
+  value=getProperty(name);
+  if(value) tx->eer_pgain=atof(value);
+  sprintf(name,"transmitter[%d].eer_mgain",tx->channel);
+  value=getProperty(name);
+  if(value) tx->eer_mgain=atof(value);
+  sprintf(name,"transmitter[%d].eer_pdelay",tx->channel);
+  value=getProperty(name);
+  if(value) tx->eer_pdelay=atof(value);
+  sprintf(name,"transmitter[%d].eer_mdelay",tx->channel);
+  value=getProperty(name);
+  if(value) tx->eer_mdelay=atof(value);
+  sprintf(name,"transmitter[%d].eer_enable_delays",tx->channel);
+  value=getProperty(name);
+  if(value) tx->eer_enable_delays=atoi(value);
+  sprintf(name,"transmitter[%d].eer_pwm_min",tx->channel);
+  value=getProperty(name);
+  if(value) tx->eer_pwm_min=atoi(value);
+  sprintf(name,"transmitter[%d].eer_pwm_max",tx->channel);
+  value=getProperty(name);
+  if(value) tx->eer_pwm_max=atoi(value);
 }
 
 static gboolean update_timer_cb(void *data) {
@@ -323,6 +376,40 @@ void transmitter_set_ps(TRANSMITTER *tx,gboolean state) {
   }
 }
 
+void transmitter_enable_eer(TRANSMITTER *tx,gboolean state) {
+  tx->eer=state;
+  SetEERRun(0, tx->eer);
+}
+void transmitter_set_eer_mode_amiq(TRANSMITTER *tx,gboolean state) {
+  tx->eer_amiq=state;
+  SetEERAMIQ(0, tx->eer_amiq); // 0=phase only, 1=magnitude and phase, 2=magnitude only (not supported here)
+}
+
+void transmitter_enable_eer_delays(TRANSMITTER *tx,gboolean state) {
+  tx->eer_enable_delays=state;
+  SetEERRunDelays(0, tx->eer_enable_delays);
+}
+
+void transmitter_set_eer_pgain(TRANSMITTER *tx,gdouble gain) {
+  tx->eer_pgain=gain;
+  SetEERPgain(0, tx->eer_pgain);
+}
+
+void transmitter_set_eer_pdelay(TRANSMITTER *tx,gdouble delay) {
+  tx->eer_pdelay=delay;
+  SetEERPdelay(0, tx->eer_pdelay/1e6);
+}
+
+void transmitter_set_eer_mgain(TRANSMITTER *tx,gdouble gain) {
+  tx->eer_mgain=gain;
+  SetEERMgain(0, tx->eer_mgain);
+}
+
+void transmitter_set_eer_mdelay(TRANSMITTER *tx,gdouble delay) {
+  tx->eer_mdelay=delay;
+  SetEERMdelay(0, tx->eer_mdelay/1e6);
+}
+
 void transmitter_set_twotone(TRANSMITTER *tx,gboolean state) {
 g_print("transmitter_set_twotone: %d\n",state);
   tx->ps_twotone=state;
@@ -348,10 +435,15 @@ void transmitter_set_ps_sample_rate(TRANSMITTER *tx,int rate) {
 static void full_tx_buffer(TRANSMITTER *tx) {
   long isample;
   long qsample;
+  long lsample;
+  long rsample;
   double gain;
   int j;
   int error;
   int mode;
+
+// round half towards zero
+#define ROUNDHTZ(x) ((x)>=0.0?(long)floor((x)*gain+0.5):(long)ceil((x)*gain-0.5))
 
   switch(radio->discovered->protocol) {
 #ifdef RADIOBERRY
@@ -384,14 +476,25 @@ static void full_tx_buffer(TRANSMITTER *tx) {
       }
     }
 */
+
     for(j=0;j<tx->output_samples;j++) {
-      double is=tx->iq_output_buffer[j*2];
-      double qs=tx->iq_output_buffer[(j*2)+1];
-      isample=is>=0.0?(long)floor(is*gain+0.5):(long)ceil(is*gain-0.5);
-      qsample=qs>=0.0?(long)floor(qs*gain+0.5):(long)ceil(qs*gain-0.5);
+      tx->inI[j]=tx->iq_output_buffer[j*2];
+      tx->inQ[j]=tx->iq_output_buffer[(j*2)+1];
+    }
+    // EER processing
+    // input is TX IQ samples in inI,inQ
+    // output phase/IQ/magnitude is written back to inI,inQ and
+    //   outMI,outMQ contain the scaled and delayed input samples
+    xeerEXTF(0, tx->inI, tx->inQ, tx->inI, tx->inQ, tx->outMI, tx->outMQ, isTransmitting(radio), tx->output_samples);
+
+    for(j=0;j<tx->output_samples;j++) {
+      isample=ROUNDHTZ(tx->inI[j]);
+      qsample=ROUNDHTZ(tx->inQ[j]);
+      lsample=ROUNDHTZ(tx->outMI[j]);
+      rsample=ROUNDHTZ(tx->outMQ[j]);
       switch(radio->discovered->protocol) {
         case PROTOCOL_1:
-          protocol1_iq_samples(isample,qsample);
+          protocol1_iq_samples(isample,qsample,lsample,rsample);
           break;
         case PROTOCOL_2:
           protocol2_iq_samples(isample,qsample);
@@ -406,6 +509,7 @@ static void full_tx_buffer(TRANSMITTER *tx) {
       }
     }
   }
+#undef ROUNDHTZ
 }
 
 void add_mic_sample(TRANSMITTER *tx,short mic_sample) {
@@ -673,6 +777,12 @@ g_print("create_transmitter: channel=%d\n",channel);
   tx->alex_forward_power=0;
   tx->alex_reverse_power=0;
 
+  tx->eer_amiq=1;
+  tx->eer_pgain=0.5;
+  tx->eer_mgain=0.5;
+  tx->eer_pdelay=200;
+  tx->eer_mdelay=200;
+  tx->eer_enable_delays=TRUE;
   tx->eer_pwm_min=100;
   tx->eer_pwm_max=800;
 
@@ -703,6 +813,12 @@ g_print("create_transmitter: channel=%d\n",channel);
   tx->mic_samples=0;
   tx->mic_input_buffer=g_new(gdouble,2*tx->buffer_size);
   tx->iq_output_buffer=g_new(gdouble,2*tx->output_samples);
+
+  // EER buffers
+  tx->inI=g_new(gfloat,tx->output_samples);
+  tx->inQ=g_new(gfloat,tx->output_samples);
+  tx->outMI=g_new(gfloat,tx->output_samples);
+  tx->outMQ=g_new(gfloat,tx->output_samples);
 
   tx->pre_emphasize=FALSE;
   tx->enable_equalizer=FALSE;
@@ -803,6 +919,19 @@ g_print("create_transmitter: channel=%d\n",channel);
 
   SetTXACompressorGain(tx->channel, tx->compressor_level);
   SetTXACompressorRun(tx->channel, tx->compressor);
+
+  create_eerEXT(0, // id
+                0, // run
+                tx->buffer_size, // size
+                48000, // rate
+                tx->eer_mgain, // mgain
+                tx->eer_pgain, // pgain
+                tx->eer_enable_delays, // rundelays
+                tx->eer_mdelay/1e6, // mdelay
+                tx->eer_pdelay/1e6, // pdelay
+                tx->eer_amiq); // amiq
+
+  SetEERRun(0, 1);
 
   transmitter_set_mode(tx,mode);
 

--- a/transmitter.h
+++ b/transmitter.h
@@ -48,6 +48,13 @@ typedef struct _transmitter {
   gboolean tune_use_drive;
   gint attenuation;
 
+  gboolean eer;
+  gint eer_amiq;
+  gdouble eer_pgain;
+  gdouble eer_pdelay;
+  gdouble eer_mgain;
+  gdouble eer_mdelay;
+  gboolean eer_enable_delays;
   gint eer_pwm_min;
   gint eer_pwm_max;
 
@@ -65,6 +72,7 @@ typedef struct _transmitter {
   gint mic_samples;
   gdouble *mic_input_buffer;
   gdouble *iq_output_buffer;
+  gfloat *inI, *inQ, *outMI, *outMQ; // for EER
   gint mic_sample_rate;
   gint mic_dsp_rate;
   gint iq_output_rate;
@@ -129,5 +137,13 @@ extern void transmitter_set_ctcss(TRANSMITTER *tx,gboolean run,gdouble frequency
 extern void transmitter_set_ps(TRANSMITTER *tx,gboolean state);
 extern void transmitter_set_twotone(TRANSMITTER *tx,gboolean state);
 extern void transmitter_set_ps_sample_rate(TRANSMITTER *tx,int rate);
+
+extern void transmitter_enable_eer(TRANSMITTER *tx,gboolean state);
+extern void transmitter_set_eer_mode_amiq(TRANSMITTER *tx,gboolean state);
+extern void transmitter_enable_eer_delays(TRANSMITTER *tx,gboolean state);
+extern void transmitter_set_eer_pgain(TRANSMITTER *tx,gdouble gain);
+extern void transmitter_set_eer_pdelay(TRANSMITTER *tx,gdouble delay);
+extern void transmitter_set_eer_mgain(TRANSMITTER *tx,gdouble gain);
+extern void transmitter_set_eer_mdelay(TRANSMITTER *tx,gdouble delay);
 
 #endif


### PR DESCRIPTION
Add an EER configuration tab similar to the one in PowerSDR and the related code to send the configuration data to the radio.
Tested to work fine on an Hermes-Lite.
Needs the EER functions declarations in WDSP added in g0orx/WDSP#5.

Modifications were done only for Protocol 1.

![eer_tab](https://user-images.githubusercontent.com/9018179/48870384-001b1700-ede1-11e8-9d9e-dea6bf6b13ae.png)
