### PR TITLE
Exit properly on window close

### DIFF
--- a/main.c
+++ b/main.c
@@ -95,9 +95,8 @@ static gboolean main_delete (GtkWidget *widget) {
         break;
 #endif
     }
-  } else {
-    _exit(0);
-  }
+  }    
+  _exit(0);
 }
 
 static gpointer wisdom_thread(gpointer arg) {


### PR DESCRIPTION
After 6675f95 linhpsdr no longer exits when I click the window close icon. This fixes that behavior.