### PR TITLE
various fixes for macOS

### DIFF
--- a/Makefile.mac
+++ b/Makefile.mac
@@ -97,7 +97,6 @@ button_text.c\
 wideband.c\
 vox.c\
 ext.c\
-smartsdr_server.c\
 configure_dialog.c\
 bookmark_dialog.c\
 puresignal_dialog.c\
@@ -148,7 +147,6 @@ button_text.h\
 wideband.h\
 vox.h\
 ext.h\
-smartsdr_server.h\
 configure_dialog.h\
 bookmark_dialog.h\
 puresignal_dialog.h\
@@ -198,7 +196,6 @@ button_text.o\
 wideband.o\
 vox.o\
 ext.o\
-smartsdr_server.o\
 configure_dialog.o\
 bookmark_dialog.o\
 puresignal_dialog.o\

--- a/radio.c
+++ b/radio.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <sys/time.h>
 
 #include <wdsp.h>
 

--- a/radio.c
+++ b/radio.c
@@ -1107,7 +1107,9 @@ g_print("create_radio for %s %d\n",d->name,d->device);
   r->local_microphone_buffer_size=256;
   r->local_microphone_buffer_offset=0;
   r->local_microphone_buffer=NULL;
+#ifndef __APPLE__
   r->record_handle=NULL;
+#endif
 
   g_mutex_init(&r->local_microphone_mutex);
 


### PR DESCRIPTION
- radio.c: in c99 gettimeofday() requires explicit declaration
- radio.c: r->record_handle is only available on alsa/pulseaudio
- Makefile.mac: smartsdr_server is gone