### PR TITLE
CW in rx panadapter

### DIFF
--- a/radio.c
+++ b/radio.c
@@ -501,11 +501,13 @@ void frequency_changed(RECEIVER *rx) {
     gint64 offset;
     rx->ctun_offset=rx->ctun_frequency-rx->frequency_a;
     offset=rx->ctun_offset;
+    /*
     if(rx->mode_a==CWU) {
       offset+=(gint64)radio->cw_keyer_sidetone_frequency;
     } else if(rx->mode_a==CWL) {
       offset-=(gint64)radio->cw_keyer_sidetone_frequency;
     }
+    */
     if(rx->rit_enabled) {
       offset+=rx->rit;
     }

--- a/receiver.c
+++ b/receiver.c
@@ -757,22 +757,28 @@ void receiver_move_to(RECEIVER *rx,long long hz) {
 
   f=start+offset+(long long)((double)rx->pan*rx->hz_per_pixel);
   f=f/rx->step*rx->step;
+  
+  double cw_offset = 0;
+  if(rx->mode_a==CWL || rx->mode_a==CWU) {  
+    if(rx->mode_a==CWU) {
+      cw_offset=-radio->cw_keyer_sidetone_frequency;
+    } else {
+      cw_offset=+radio->cw_keyer_sidetone_frequency;
+    }  
+  }
+  
+  
 g_print("receiver_move_to: f=%lld\n",f);
   if(rx->ctun) {
     delta=rx->ctun_frequency;
-    rx->ctun_frequency=f;
+    rx->ctun_frequency=f + cw_offset;
     delta=rx->ctun_frequency-delta;
   } else {
-    if(rx->split==SPLIT_ON && (rx->mode_a==CWL || rx->mode_a==CWU)) {
-      if(rx->mode_a==CWU) {
-        f=f-radio->cw_keyer_sidetone_frequency;
-      } else {
-        f=f+radio->cw_keyer_sidetone_frequency;
-      }
-      rx->frequency_b=f;
+    if((rx->split==SPLIT_ON) && (rx->mode_a==CWL || rx->mode_a==CWU)) {
+      rx->frequency_b=f + cw_offset;  
     } else {
       delta=rx->frequency_a;
-      rx->frequency_a=f;
+      rx->frequency_a=f + cw_offset;
       delta=rx->frequency_a-delta;
     }
   }


### PR DESCRIPTION
- In CWU or CWL, clicking on the peak of a CW signal moves the VFO to this frequency
- Upper and lower band limits now function correctly with the rx pan feature
- Sporadic blue dashed lines on rx panadapter grid now fixed