### PR TITLE
Fixed linking errors for GCC 10.1.1

### DIFF
--- a/band.h
+++ b/band.h
@@ -84,8 +84,8 @@ typedef struct _CHANNEL {
     long long width;
 } CHANNEL;
 
-int band;
-gboolean displayHF;
+extern int band;
+//extern gboolean displayHF;
 
 #define UK_CHANNEL_ENTRIES 11
 #define OTHER_CHANNEL_ENTRIES 5

--- a/midi.h
+++ b/midi.h
@@ -46,6 +46,10 @@
 // MIDIaction encodes the "action" to be taken in Layer3
 // (sorted alphabetically by the keyword)
 //
+
+#ifndef _MIDI_H
+#define _MIDI_H
+
 enum MIDIaction {
   ACTION_NONE=0,	// NONE:		No-Op (unassigned key)
   VFO_A2B,		// A2B:			VFO A -> B
@@ -199,10 +203,12 @@ struct desc {
    struct desc       *next;       // Next defined action for a controller/key with that note value (NULL for end of list)
 };
 
-struct {
+struct _MidiCommandsTable {
    struct desc *desc[128];    // description for Note On/Off and ControllerChange
    struct desc *pitch;        // description for PitchChanges
-} MidiCommandsTable;
+};
+
+extern struct _MidiCommandsTable MidiCommandsTable;
 
 //
 // Layer-1 entry point, called once for all the MIDI devices
@@ -232,3 +238,5 @@ int MIDIstartup();
 //
 
 void DoTheMidi(enum MIDIaction code, enum MIDItype type, int val);
+
+#endif

--- a/midi2.c
+++ b/midi2.c
@@ -14,6 +14,8 @@
 #include <time.h>
 #include "midi.h"
 
+struct _MidiCommandsTable MidiCommandsTable;
+
 void NewMidiEvent(enum MIDIevent event, int channel, int note, int val) {
 
     struct desc *desc;


### PR DESCRIPTION
multiple definition of struct MidiCommandsTable, int band and gboolean displayHF 