### PR TITLE
macOS fixes and clear

### DIFF
--- a/Makefile.mac
+++ b/Makefile.mac
@@ -3,23 +3,11 @@
 GIT_DATE := $(firstword $(shell git --no-pager show --date=short --format="%ai" --name-only))
 GIT_VERSION := $(shell git describe --abbrev=0 --tags)
 
-CC?=gcc
-LINK?=gcc
+LINK?=$(CC)
 
 GTKINCLUDES=`pkg-config --cflags gtk+-3.0`
 GTKLIBS=`pkg-config --libs gtk+-3.0`
 
-#OPENGL_OPTIONS=-D OPENGL
-#OPENGL_INCLUDES=`pkg-config --cflags epoxy`
-#OPENGL_LIBS=`pkg-config --libs epoxy`
-
-#PULSEINCLUDES=`pkg-config --cflags libpulse`
-#PULSELIBS=`pkg-config --libs libpulse`
-#PULSESIMPLELIBS=`pkg-config --libs libpulse-simple`
-#PULSEMAINLOOPLIBS=`pkg-config --libs libpulse-mainloop-glib`
-
-
-#AUDIO_LIBS=-lpulse-simple -lpulse -lpulse-mainloop-glib
 AUDIOLIBS=-lsoundio
 
 # uncomment the line below to include SoapySDR support
@@ -49,11 +37,21 @@ soapy_discovery.o \
 soapy_protocol.o
 endif
 
+# MIDI code from piHPSDR written by Christoph van Wullen, DL1YCF.
+MIDI_INCLUDE=MIDI
 
-OPTIONS=-Wno-deprecated-declarations -D SOUNDIO -D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(SOAPYSDR_OPTIONS) $(OPENGL_OPTIONS) -O3 -g
+ifeq ($(MIDI_INCLUDE),MIDI)
+MIDI_OPTIONS=-D MIDI
+MIDI_SOURCES= alsa_midi.c midi2.c midi3.c midi_dialog.c
+MIDI_HEADERS= midi.h midi_dialog.h
+MIDI_OBJS= alsa_midi.o midi2.o midi3.o midi_dialog.o
+MIDI_LIBS= -lasound
+endif
+
+OPTIONS=-Wno-deprecated-declarations -D SOUNDIO -D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(SOAPYSDR_OPTIONS) -O3 -g
 
 LIBS=-lm -lpthread -lwdsp
-INCLUDES=$(GTKINCLUDES) $(PULSEINCLUDES) $(OPENGL_INCLUDES)
+INCLUDES=$(GTKINCLUDES)
 
 COMPILE=$(CC) $(OPTIONS) $(INCLUDES)
 
@@ -61,6 +59,7 @@ PROGRAM=linhpsdr
 
 SOURCES=\
 main.c\
+css.c\
 audio.c\
 version.c\
 discovered.c\
@@ -106,10 +105,12 @@ frequency.c\
 rigctl.c\
 error_handler.c\
 radio_info.c\
-bpsk.c
+bpsk.c \
+subrx.c
 
 HEADERS=\
 main.h\
+css.h\
 audio.h\
 version.h\
 discovered.h\
@@ -156,10 +157,12 @@ frequency.h\
 rigctl.h\
 error_handler.h\
 radio_info.h\
-bpsk.h
+bpsk.h\
+subrx.h
 
 OBJS=\
 main.o\
+css.o \
 audio.o\
 version.o\
 discovered.o\
@@ -205,7 +208,8 @@ frequency.o\
 rigctl.o\
 error_handler.o\
 radio_info.o\
-bpsk.o
+bpsk.o \
+subrx.o
 
 all: prebuild  $(PROGRAM) $(HEADERS) $(SOURCES) $(SOAPYSDR_SOURCES)
 
@@ -213,7 +217,7 @@ prebuild:
 	rm -f version.o
 
 $(PROGRAM):  $(OBJS) $(SOAPYSDR_OBJS)
-	$(LINK) -o $(PROGRAM) $(OBJS) $(SOAPYSDR_OBJS) $(GTKLIBS) $(LIBS) $(AUDIOLIBS) $(SOAPYSDR_LIBS) $(OPENGL_LIBS)
+	$(LINK) -o $(PROGRAM) $(OBJS) $(SOAPYSDR_OBJS) $(GTKLIBS) $(LIBS) $(AUDIOLIBS) $(SOAPYSDR_LIBS) $(LDFLAGS)
 
 .c.o:
 	$(COMPILE) -c -o $@ $<

--- a/rigctl.c
+++ b/rigctl.c
@@ -69,6 +69,10 @@
 
 #define NEW_PARSER
 
+// SOL_TCP is not defined on macOS/*BSD
+#if !defined(SOL_TCP) && defined(IPPROTO_TCP)
+#define SOL_TCP IPPROTO_TCP
+#endif
 
 int rigctl_port_base=19090;
 int rigctl_enable=0;


### PR DESCRIPTION
- rigctl.c: SOL_TCP is undefined on macOS/*BSD
   replace SOL_TCP with IPPROTO_TCP
- remove opengl and pulseaudio build options
- fix CC variable

thanks to DL1YCF