### PR TITLE
Making protocol discovery compatible with wireguard interfaces present

### DIFF
--- a/protocol1_discovery.c
+++ b/protocol1_discovery.c
@@ -117,7 +117,7 @@ static void discover(struct ifaddrs* iface) {
 
     if(sendto(discovery_socket,buffer,63,0,(struct sockaddr*)&to_addr,sizeof(to_addr))<0) {
         perror("discover: sendto socket failed for discovery_socket\n");
-        if(errno!=EHOSTUNREACH && errno!=EADDRNOTAVAIL) {
+        if(errno!=EHOSTUNREACH && errno!=EADDRNOTAVAIL && errno!=ENOKEY) {
             exit(-1);
         }
     }

--- a/protocol2_discovery.c
+++ b/protocol2_discovery.c
@@ -168,7 +168,7 @@ void protocol2_discover(struct ifaddrs* iface) {
 
     if(sendto(discovery_socket,buffer,60,0,(struct sockaddr*)&to_addr,sizeof(to_addr))<0) {
         perror("protocol2_discover: sendto socket failed for discovery_socket\n");
-        if(errno!=EHOSTUNREACH) {
+        if(errno!=EHOSTUNREACH && errno!=ENOKEY) {
             exit(-1);
         }
     }


### PR DESCRIPTION
As soon you have wireguard VPN *1) interfaces present, the discovery fails.

The copy+paste solution was presented by @zvpunry in May 2021 *3), but never implemented by you.
Since that error hit myself, I've decided to take action by forking the master branch and doing this pull request.

*1) https://www.wireguard.com/
*2) https://github.com/zvpunry
*3) https://github.com/g0orx/linhpsdr/issues/103
