### PR TITLE
Fix C type errors in audio.c

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -624,15 +624,15 @@ g_print("audio_open_input: format=%d\n",record_audio_format);
       switch(record_audio_format) {
         case SND_PCM_FORMAT_S16_LE:
 g_print("audio_open_input: mic_buffer: size=%d channels=%d sample=%ld bytes\n",r->local_microphone_buffer_size,channels,sizeof(gint16));
-          r->local_microphone_buffer=g_new(gint16, r->local_microphone_buffer_size);
+          r->local_microphone_buffer=(float *)g_new(gint16, r->local_microphone_buffer_size);
           break;
         case SND_PCM_FORMAT_S32_LE:
 g_print("audio_open_input: mic_buffer: size=%d channels=%d sample=%ld bytes\n",r->local_microphone_buffer_size,channels,sizeof(gint32));
-          r->local_microphone_buffer=g_new(gint32, r->local_microphone_buffer_size);
+          r->local_microphone_buffer=(float *)g_new(gint32, r->local_microphone_buffer_size);
           break;
         case SND_PCM_FORMAT_FLOAT_LE:
 g_print("audio_open_input: mic_buffer: size=%d channels=%d sample=%ld bytes\n",r->local_microphone_buffer_size,channels,sizeof(gfloat));
-          r->local_microphone_buffer=g_new(gfloat, r->local_microphone_buffer_size);
+          r->local_microphone_buffer=(float *)g_new(gfloat, r->local_microphone_buffer_size);
           break;
           
         default: return -1;          
@@ -1035,7 +1035,7 @@ fprintf(stderr,"mic_read_thread: ALSA: mic_buffer_size=%d\n",radio->local_microp
                 //g_print("mic_read_thread: -EPIPE: snd_pcm_prepare\n");
                 if ((rc = snd_pcm_prepare (r->record_handle)) < 0) {
                     g_print("mic_read_thread: ALSA: cannot prepare audio interface for use %d (%s)\n", rc, snd_strerror (rc));
-                    return rc;
+                    return NULL;
                 }
               } else {
                 fprintf (stderr, "mic_read_thread: ALSA: read from audio interface failed (%s)\n",


### PR DESCRIPTION
Explicitly cast `gint16 *` result of `g_new` to `float *` in `audio_open_input`. Return `NULL` from `mic_read_thread` because the function returns `void *`.

This avoids build failures with current compilers which treat these C type errors as errors.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
