### PR TITLE
Fix incorrect desktop file version

### DIFF
--- a/linhpsdr.desktop
+++ b/linhpsdr.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=0.1
+Version=1.0
 Type=Application
 Terminal=false
 Name[eb_GB]=linHPSDR


### PR DESCRIPTION
It should always be 1.0.